### PR TITLE
Add support for inlining font files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,9 +48,16 @@ Base64CSS.prototype.processString = function(string) {
     if (/ttf|otf|woff|eot/.test(extension)) {
       prefix = 'application';
       filePath = path.join(fontPath, fileName);
+    } else if (/svg/.test(extension)) {
+      filePath = path.join(fontPath, fileName);
+      if (!fs.existsSync(filePath)) {
+        filePath = path.join(imagePath, fileName);
+      }
     } else {
       filePath = path.join(imagePath, fileName);
     }
+
+    if (!fs.existsSync(filePath)) return match;
 
     var size = fs.statSync(filePath).size;
     if (size > maxFileSize) return match;


### PR DESCRIPTION
- Strip any query strings or hashes from url filename
- Add fontPath option
- Set correct mime type according to font filetype

SVG files are an edge case, as they can be both images and fonts. As of now, the plugin will continue to look for SVG files in the imagePath.

My use of indexOf to detect whether the file is a font is admittedly a bit crude. Please give feedback :)
