### PR TITLE
Add assetsFromTree option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ var tree = base64CSS(tree, {
 , maxFileSize: 4096 // larger files will be left untouched
 , extensions: ['css']
 , fileTypes: ['png', 'jpg', 'jpeg', 'gif', 'svg']
+, assetsFromTree: false // look for images in same tree
+                        // as css, rather than at static paths
+                        // default: false
 });
 ```
 


### PR DESCRIPTION
Added option to look for images within the same tree as is being process...ed as opposed to at static paths. The default behavior is left unchanged.

To use this, set the `assetsFromTree` option to true.
